### PR TITLE
fix conditionals using .getTime() to handle UNIX epoch

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -86,7 +86,7 @@
             var value = new Date(this.value());
             var year, month, date;
 
-            if (!value.getTime()) {
+          if (isNaN(value.getTime())) {
                 value = new Date();
             }
 
@@ -167,7 +167,7 @@
             if (target.matches("a")) {
                 targetDate = new Date(this.value());
 
-                if (!targetDate.getTime()) targetDate = new Date();
+              if (isNaN(targetDate.getTime())) targetDate = new Date();
 
                 var sign = target.next("a")[0] ? -1 : 1;
 
@@ -181,7 +181,7 @@
 
                 targetDate = new Date(this.value());
 
-                if (!targetDate.getTime()) targetDate = new Date();
+              if (isNaN(targetDate.getTime())) targetDate = new Date();
 
                 targetDate.setUTCMonth(new Date(target.get("datetime")).getUTCMonth());
 
@@ -230,7 +230,7 @@
             } else {
                 currentDate = new Date(this.value());
 
-                if (!currentDate.getTime()) currentDate = new Date();
+              if (isNaN(currentDate.getTime())) currentDate = new Date();
 
                 if (which === 74 || which === 40) { delta = 7; }
                 else if (which === 75 || which === 38) { delta = -7; }

--- a/test/main.spec.js
+++ b/test/main.spec.js
@@ -107,6 +107,10 @@ describe("better-dateinput-polyfill", function() {
         picker.set("aria-expanded", "true");
         el._clickPicker(picker, months, target);
         expect(el.value()).toBe("1998-01-01");
+
+        el.value("1970-01-01");
+        el._clickPicker(picker, months, target);
+        expect(el.value()).toBe("1969-01-01");
     });
 
     it("changes month in month picker mode", function() {


### PR DESCRIPTION
Here's the PR for #75. I replaced the `.getTime` boolean checks with `isNaN` and added a test case for UNIX time too.