### PR TITLE
reset targetDate after a form reset with no default value

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -159,6 +159,8 @@
             if (!isNaN(date)) {
                 // #72: visible value must adjust timezone offset
                 label.set("datetime", new Date(date.getUTCFullYear(), date.getUTCMonth(), date.getUTCDate()).toISOString());
+            } else if(propName === "defaultValue"){
+                label.set("datetime", '');
             }
         },
         _clickPicker(picker, calendarMonths, target) {

--- a/src/main.js
+++ b/src/main.js
@@ -159,8 +159,8 @@
             if (!isNaN(date)) {
                 // #72: visible value must adjust timezone offset
                 label.set("datetime", new Date(date.getUTCFullYear(), date.getUTCMonth(), date.getUTCDate()).toISOString());
-            } else if(propName === "defaultValue"){
-                label.set("datetime", '');
+            } else {
+                label.set("datetime", "");
             }
         },
         _clickPicker(picker, calendarMonths, target) {


### PR DESCRIPTION
Currently, when no default value is set, a form "reset" event clears the input but does not reset the label datetime. So after clicking the reset button, opening the date picker shows the last date selected before the reset. This modification aims to fully reset the calendar state after a form reset when no default value is set.