### PR TITLE
Readme lists wrong html lang attribute

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Why another date picker? The problem is that most of existing solutions do not f
 * fully customizable date picker, including [displayed value format](https://github.com/chemerisuk/better-time-element#custom-formats) via `data-format` attribute
 * control when to apply the polyfill using [data-polyfill](#forcing-the-polyfill) attribute
 * [full i18n support](https://github.com/chemerisuk/better-i18n-plugin#multilingual-live-extensions) (localized files located at [better-time-element](https://github.com/chemerisuk/better-time-element))
-* US variant for days of week is supported (use `<html lang="en-US">`)
+* US variant for days of week is supported (use `<html lang="en_US">`)
 * * keyboard and accessibility friendly
 
 ## Installation


### PR DESCRIPTION
The file source requires <html lang="en_US">, but the readme requires <html lang="en-US">.

https://github.com/chemerisuk/better-dateinput-polyfill/blob/ff65b40aefb6b12f981d98bbd7c8fe33805c95e8/src/main.js#L8