### PR TITLE
Update Date picker to choose any date in firefox

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -110,10 +110,8 @@ DOM.extend("input[type=date]", {
         if (!dateValue) {
             value = "";
         } else {
-            const minAttribute = this.get("min");
-            const maxAttribute = this.get("max")
-            const min = new Date(minAttribute ? minAttribute + "T00:00" : '');
-            const max = new Date(maxAttribute ? maxAttribute + "T00:00" : '');
+            const min = new Date((this.get("min") || "?") + "T00:00");
+            const max = new Date((this.get("max") || "?") + "T00:00");
 
             if (dateValue < min) {
                 value = formatLocalDate(min);

--- a/src/main.js
+++ b/src/main.js
@@ -110,8 +110,10 @@ DOM.extend("input[type=date]", {
         if (!dateValue) {
             value = "";
         } else {
-            const min = new Date(this.get("min") + "T00:00");
-            const max = new Date(this.get("max") ? this.get("max") + "T00:00" : '');
+            const minAttribute = this.get("min");
+            const maxAttribute = this.get("max")
+            const min = new Date(minAttribute ? minAttribute + "T00:00" : '');
+            const max = new Date(maxAttribute ? maxAttribute + "T00:00" : '');
 
             if (dateValue < min) {
                 value = formatLocalDate(min);

--- a/src/main.js
+++ b/src/main.js
@@ -111,7 +111,7 @@ DOM.extend("input[type=date]", {
             value = "";
         } else {
             const min = new Date(this.get("min") + "T00:00");
-            const max = new Date(this.get("max") + "T00:00");
+            const max = new Date(this.get("max") ? this.get("max") + "T00:00" : '');
 
             if (dateValue < min) {
                 value = formatLocalDate(min);

--- a/src/picker.js
+++ b/src/picker.js
@@ -125,10 +125,8 @@ DOM.extend("dateinput-picker", {
         const month = dateValue.getMonth();
         const date = dateValue.getDate();
         const year = dateValue.getFullYear();
-        const minAttribute = this._parentInput.get("min");
-        const maxAttribute = this._parentInput.get("max")
-        const min = new Date(minAttribute ? minAttribute + "T00:00" : '');
-        const max = new Date(maxAttribute ? maxAttribute + "T00:00" : '');
+        const min = new Date((this._parentInput.get("min") || "?") + "T00:00");
+        const max = new Date((this._parentInput.get("max") || "?") + "T00:00");
         const iterDate = new Date(year, month, 1);
         // move to beginning of the first week in current month
         iterDate.setDate(1 - iterDate.getDay() - ampm(1, iterDate.getDay() === 0 ? 7 : 0));
@@ -159,10 +157,8 @@ DOM.extend("dateinput-picker", {
     _invalidateMonths(dateValue) {
         const month = dateValue.getMonth();
         const year = dateValue.getFullYear();
-        const minAttribute = this._parentInput.get("min");
-        const maxAttribute = this._parentInput.get("max")
-        const min = new Date(minAttribute ? minAttribute + "T00:00" : '');
-        const max = new Date(maxAttribute ? maxAttribute + "T00:00" : '');
+        const min = new Date((this._parentInput.get("min") || "?") + "T00:00");
+        const max = new Date((this._parentInput.get("max") || "?") + "T00:00");
         const iterDate = new Date(year, month, 1);
 
         this._calendarMonths.findAll("td").forEach((day, index) => {

--- a/src/picker.js
+++ b/src/picker.js
@@ -125,8 +125,10 @@ DOM.extend("dateinput-picker", {
         const month = dateValue.getMonth();
         const date = dateValue.getDate();
         const year = dateValue.getFullYear();
-        const min = new Date(this._parentInput.get("min") + "T00:00");
-        const max = new Date(this._parentInput.get("max") ? this._parentInput.get("max") + "T00:00" : '');
+        const minAttribute = this._parentInput.get("min");
+        const maxAttribute = this._parentInput.get("max")
+        const min = new Date(minAttribute ? minAttribute + "T00:00" : '');
+        const max = new Date(maxAttribute ? maxAttribute + "T00:00" : '');
         const iterDate = new Date(year, month, 1);
         // move to beginning of the first week in current month
         iterDate.setDate(1 - iterDate.getDay() - ampm(1, iterDate.getDay() === 0 ? 7 : 0));
@@ -157,8 +159,10 @@ DOM.extend("dateinput-picker", {
     _invalidateMonths(dateValue) {
         const month = dateValue.getMonth();
         const year = dateValue.getFullYear();
-        const min = new Date(this._parentInput.get("min") + "T00:00");
-        const max = new Date(this._parentInput.get("max") ? this._parentInput.get("max") + "T00:00" : '');
+        const minAttribute = this._parentInput.get("min");
+        const maxAttribute = this._parentInput.get("max")
+        const min = new Date(minAttribute ? minAttribute + "T00:00" : '');
+        const max = new Date(maxAttribute ? maxAttribute + "T00:00" : '');
         const iterDate = new Date(year, month, 1);
 
         this._calendarMonths.findAll("td").forEach((day, index) => {

--- a/src/picker.js
+++ b/src/picker.js
@@ -126,7 +126,7 @@ DOM.extend("dateinput-picker", {
         const date = dateValue.getDate();
         const year = dateValue.getFullYear();
         const min = new Date(this._parentInput.get("min") + "T00:00");
-        const max = new Date(this._parentInput.get("max") + "T00:00");
+        const max = new Date(this._parentInput.get("max") ? this._parentInput.get("max") + "T00:00" : '');
         const iterDate = new Date(year, month, 1);
         // move to beginning of the first week in current month
         iterDate.setDate(1 - iterDate.getDay() - ampm(1, iterDate.getDay() === 0 ? 7 : 0));
@@ -158,7 +158,7 @@ DOM.extend("dateinput-picker", {
         const month = dateValue.getMonth();
         const year = dateValue.getFullYear();
         const min = new Date(this._parentInput.get("min") + "T00:00");
-        const max = new Date(this._parentInput.get("max") + "T00:00");
+        const max = new Date(this._parentInput.get("max") ? this._parentInput.get("max") + "T00:00" : '');
         const iterDate = new Date(year, month, 1);
 
         this._calendarMonths.findAll("td").forEach((day, index) => {


### PR DESCRIPTION
Firefox parses dates in its constructor differently than other browsers, so when max/min attributes are not set on a field, the Date constructor calls new Date("T00:00") which is interpreted as 1970-01-01T08:00:00.000Z`` in Firefox but Invalid Date``` in other browsers. This led to ONLY 1/1/1970 as a valid value as it was being set as both max and min value.

Now, if the get of max/min returns a falsey value, the Date constructor is called with an empty string, which (should? I don't want to spin up my IE VM to double check) return an Invalid Date for all browsers.

closes issue #118 