### PR TITLE
Adds eventlistener support via document.createEvent

### DIFF
--- a/src/picker.js
+++ b/src/picker.js
@@ -124,6 +124,13 @@ export class DatePickerImpl {
         if (target.getAttribute("aria-disabled") !== "true") {
             this._input.value = target.getAttribute("data-date");
             this.hide();
+
+            // Dispatch change event
+            if (document.createEvent) {
+                const evt = document.createEvent('HTMLEvents');
+                evt.initEvent('change', true, false);
+                this._input.dispatchEvent(evt)
+            }
         }
     }
 


### PR DESCRIPTION
Addresses: https://github.com/chemerisuk/better-dateinput-polyfill/issues/134

## Problem

As mentioned in the issue, you currently can't listen for changes on a polyfilled input. This is problematic if you're using React and other frameworks, since the React state & the state of the input will get out of sync.

## Solution

I have added a few lines of code to trigger an event that will closely mirror the event that would come from an actual date input in Chrome / Firefox.

* I have chosen to use the older `document.createEvent` interface, since it has wider support with browsers that are lacking the date input, and it has better compatibility with React
* I have tested this with React, as well as a vanilla `input.addEventListener`, and both worked successfully.